### PR TITLE
Make Automations, Scripts, and Helpers stat cards clickable with info…

### DIFF
--- a/custom_components/entity_manager/frontend/entity-manager-panel.css
+++ b/custom_components/entity_manager/frontend/entity-manager-panel.css
@@ -1005,7 +1005,7 @@ body.em-dialog-open {
   opacity: 0.9;
 }
 
-.entity-list-row .entity-list-toggle {
+.entity-list-row .entity-list-actions {
   margin-left: auto;
 }
 
@@ -1022,6 +1022,12 @@ body.em-dialog-open {
 
   .entity-list-row .entity-list-toggle {
     margin-left: auto;
+    margin-top: 6px;
+  }
+
+  .entity-list-actions {
+    flex-basis: 100%;
+    justify-content: flex-end;
     margin-top: 6px;
   }
 }
@@ -1051,6 +1057,56 @@ body.em-dialog-open {
 
 .entity-list-toggle:hover {
   opacity: 0.8;
+}
+
+.entity-list-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.entity-list-action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 1px solid var(--em-border, #e0e0e0);
+  background: var(--em-bg-secondary, #f5f5f5);
+  color: var(--em-text-secondary, #757575);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  padding: 0;
+}
+
+.entity-list-action-btn:hover {
+  background: var(--em-primary, #2196f3);
+  color: white;
+  border-color: var(--em-primary, #2196f3);
+  transform: scale(1.1);
+}
+
+.entity-list-action-btn.info-btn:hover {
+  background: #2196f3;
+  border-color: #2196f3;
+}
+
+.entity-list-action-btn.edit-btn:hover {
+  background: #ff9800;
+  border-color: #ff9800;
+}
+
+.confirm-dialog-overlay[data-theme="dark"] .entity-list-action-btn {
+  background: var(--em-bg-primary, #1e1e1e);
+  border-color: var(--em-border, #333);
+  color: var(--em-text-secondary, #aaa);
+}
+
+.confirm-dialog-overlay[data-theme="dark"] .entity-list-action-btn:hover {
+  color: white;
 }
 
 [data-theme="dark"] .confirm-no {

--- a/custom_components/entity_manager/frontend/entity-manager-panel.js
+++ b/custom_components/entity_manager/frontend/entity-manager-panel.js
@@ -4625,19 +4625,26 @@ class EntityManagerPanel extends HTMLElement {
         <div class="stat-label">Total Entities</div>
         <div class="stat-value">${totalEntities}</div>
       </div>
-      <div class="stat-card">
+      <div class="stat-card clickable-stat" data-stat-type="automation" title="Click to view automations">
         <div class="stat-label">Automations</div>
         <div class="stat-value" style="color: #2196f3 !important;">${this.automationCount}</div>
       </div>
-      <div class="stat-card">
+      <div class="stat-card clickable-stat" data-stat-type="script" title="Click to view scripts">
         <div class="stat-label">Scripts</div>
         <div class="stat-value" style="color: #2196f3 !important;">${this.scriptCount}</div>
       </div>
-      <div class="stat-card">
+      <div class="stat-card clickable-stat" data-stat-type="helper" title="Click to view helpers">
         <div class="stat-label">Helpers</div>
         <div class="stat-value" style="color: #2196f3 !important;">${this.helperCount}</div>
       </div>
     `;
+
+    // Attach click listeners to clickable stat cards
+    statsEl.querySelectorAll('.clickable-stat[data-stat-type]').forEach(card => {
+      card.addEventListener('click', () => {
+        this.showEntityListDialog(card.dataset.statType);
+      });
+    });
 
     const allBtn = this.content.querySelector('[data-filter="all"]');
     const enabledBtn = this.content.querySelector('[data-filter="enabled"]');
@@ -5658,11 +5665,19 @@ class EntityManagerPanel extends HTMLElement {
             <span class="entity-list-name">${e.name}</span>
             <span class="entity-list-id-inline">${e.id}</span>
             ${e.meta ? `<span class="entity-list-id-inline">${e.meta}</span>` : ''}
-            ${allowToggle ? `
-              <button class="entity-list-toggle ${e.state === 'on' ? 'on' : 'off'}" data-entity-id="${e.id}" data-entity-type="${type}">
-                ${e.state === 'on' ? 'On' : 'Off'}
+            <span class="entity-list-actions">
+              ${allowToggle ? `
+                <button class="entity-list-toggle ${e.state === 'on' ? 'on' : 'off'}" data-entity-id="${e.id}" data-entity-type="${type}">
+                  ${e.state === 'on' ? 'On' : 'Off'}
+                </button>
+              ` : ''}
+              <button class="entity-list-action-btn info-btn" data-entity-id="${e.id}" title="Show info">
+                <svg viewBox="0 0 24 24" width="16" height="16"><path d="M13,9H11V7H13M13,17H11V11H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z" fill="currentColor"/></svg>
               </button>
-            ` : ''}
+              <button class="entity-list-action-btn edit-btn" data-entity-id="${e.id}" data-entity-type="${type}" title="Edit in HA">
+                <svg viewBox="0 0 24 24" width="16" height="16"><path d="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z" fill="currentColor"/></svg>
+              </button>
+            </span>
           </div>
         </div>
       `).join('');
@@ -5689,7 +5704,7 @@ class EntityManagerPanel extends HTMLElement {
             e.stopPropagation();
             const entityId = btn.dataset.entityId;
             const currentlyOn = btn.classList.contains('on');
-            
+
             btn.disabled = true;
             btn.style.opacity = '0.7';
             try {
@@ -5710,7 +5725,49 @@ class EntityManagerPanel extends HTMLElement {
           });
         });
       }
-      
+
+      // Info buttons - open HA's more-info dialog
+      overlay.querySelectorAll('.entity-list-action-btn.info-btn').forEach(btn => {
+        btn.addEventListener('click', (e) => {
+          e.stopPropagation();
+          const entityId = btn.dataset.entityId;
+          const event = new CustomEvent('hass-more-info', {
+            detail: { entityId },
+            bubbles: true,
+            composed: true,
+          });
+          document.querySelector('home-assistant')?.dispatchEvent(event) ||
+            this.dispatchEvent(event);
+        });
+      });
+
+      // Edit buttons - navigate to HA's edit page
+      overlay.querySelectorAll('.entity-list-action-btn.edit-btn').forEach(btn => {
+        btn.addEventListener('click', (e) => {
+          e.stopPropagation();
+          const entityId = btn.dataset.entityId;
+          const entityType = btn.dataset.entityType;
+          let editPath = '';
+
+          if (entityType === 'automation') {
+            // automation.my_auto -> my_auto
+            const autoId = entityId.replace('automation.', '');
+            editPath = `/config/automation/edit/${autoId}`;
+          } else if (entityType === 'script') {
+            const scriptId = entityId.replace('script.', '');
+            editPath = `/config/script/edit/${scriptId}`;
+          } else if (entityType === 'helper') {
+            editPath = `/config/helpers`;
+          }
+
+          if (editPath) {
+            closeDialog();
+            history.pushState(null, '', editPath);
+            window.dispatchEvent(new CustomEvent('location-changed'));
+          }
+        });
+      });
+
     } catch (error) {
       console.error('Error loading entity list:', error);
       this.showErrorDialog(`Error loading ${title}: ${error.message}`);


### PR DESCRIPTION
…/edit actions

- Add clickable-stat class and data-stat-type attributes to the three stat cards
- Wire up click listeners to open the existing showEntityListDialog for each type
- Add info button (opens HA's more-info dialog) and edit button (navigates to HA's native edit page) to each entity row in the dialog
- Add CSS for action buttons with hover states, dark mode support, and mobile responsive layout

https://claude.ai/code/session_016nws31oaDd34itXpY8bgCN