### PR TITLE
V2.9.2 retouch and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,18 @@
 ### 📚 Version Alignment
 - Updated all version references (manifest, README, package.json, docs) to 2.9.0
 - Synchronized version across frontend, backend, and configuration files
-
+### ✨ New Features
+- **Lovelace Dashboard Card** - Added documentation and configuration guide for custom `entity-manager-card`
+  - Search and filter entities directly from dashboard
+  - Bulk operations support
+  - Compact and full-size layout options
+  - Integration and domain filtering
+- **Template Sensors** - Added configuration examples for entity statistics
+  - Disabled entities count
+  - Enabled entities count
+  - Total entities tracking
+  - Integration-based statistics
+  - Automation-ready sensor states
 ---
 
 ## Version 2.8.1 - UI Polish & Safety

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,123 @@
 # Changelog
 
+## Version 2.9.2 - Entity Detail, Update Manager & UI Polish
+
+### ✨ New Features
+
+#### Entity Detail Dialog
+- **Click any entity card** to open a full detail dialog showing everything HA knows about that entity
+- New backend WebSocket command `entity_manager/get_entity_details` pulls from entity registry, device registry, area registry, label registry, and config entry — all in one call
+- Eight collapsible sections: **Overview** (entity ID, friendly name, domain, platform, unique ID, aliases), **Current State** (large state value + all attributes sorted A–Z), **Registry** (category, device class, disabled/hidden state, icon, unit, supported features), **Device** (manufacturer, model, SW/HW version, serial, config URL, connections), **Integration** (title, domain, source, version, state), **Area**, **Labels**, **State History** (last 30 days, newest first)
+- Overview and Current State sections open by default; all others collapsed
+- Action buttons in dialog footer: Rename, Enable/Disable toggle, Close
+- Dialog is wider (680 px) and scrollable for long attribute lists
+
+#### Entity Card Redesign
+- **Dark header band** at top of each card shows device name, state chip, and time-ago chip
+- Entity ID is the visual centrepiece of the card body
+- Enabled/Disabled badge sits below the entity ID as its own line
+- Checkbox and favourite star moved to the bottom-left action row alongside Edit/Enable/Disable buttons
+- Clicking the card background (not buttons/checkbox/star) opens the detail dialog
+
+#### Updates — HA Auto-Backup Toggle
+- **Banner below Select All** shows the current state of HA's global "backup before update" setting (`core_backup_before_update` / `add_on_backup_before_update`)
+- Green tinted border when ON; red tinted border when OFF — impossible to miss either state
+- Descriptive subtitle explains what the setting does in each state
+- Click the ON/OFF button to toggle instantly via `hassio/update/config/update`
+- Only shown on HA OS / Supervised (uses hassio supervisor API); hidden silently on plain HA Core
+
+#### Updates — Per-Row Backup Checkbox
+- Each update row with `UpdateEntityFeature.BACKUP` support shows a **🛡 Backup** checkbox
+- "Backup All (N)" header checkbox checks every supported entity at once
+- Backup label styled with green border/text to match the Update button; Release Notes button styled blue
+
+#### Updates — Sequential Queue with Row-Level Progress
+- Bulk updates now **always run sequentially** (one at a time) — parallel execution was unsafe when HA's global auto-backup is enabled since the backup system is single-threaded
+- All selected rows immediately enter **⏳ Queued** state (dimmed)
+- The active row shows a **blue border**, sweeping indeterminate progress bar at the bottom, spinning circle, and "🛡 Backing up…" or "Updating…" label
+- Each completed row shows **✓ Updated** (green) or **✕ Failed** (red) before the list refreshes
+- Live toast updates per step; final summary toast shows "✓ N updated · ✕ N failed"
+- Single-item updates also show active → done/failed row states
+
+#### Updates — Live Progress Tracking
+- Update rows **watch HA entity state in real-time** via the `set hass()` hook — no polling
+- When HA reports `update_percentage` on the entity, the spinner switches to an **SVG progress ring** showing the exact percentage
+- When the entity transitions to `state: off` (update complete), the row automatically marks done and reloads the list
+- A 5-minute fallback timer catches cases where HA does not push a state update
+
+#### Updates — UX Refinements
+- **Search bar** repositioned below the action bar (was inline with buttons) for a cleaner layout
+- **"Update Selected" pill button** expands smoothly out of the right edge of the Select All pill using a `max-width` CSS animation — collapses to zero when nothing is selected, fully invisible
+- **Refresh** while on the Updates page now reloads the updates list instead of navigating away to the entity list
+
+#### Entity List — Total Entities Card
+- **Total Entities stat card is now clickable** — opens a grouped entity list dialog (Integration → Device → entity rows)
+- Each entity row shows a status dot (green = enabled, grey = disabled), category badge, and disabled badge
+- Hash/UUID platform names (raw config entry IDs) are bucketed under an **"Other"** group instead of being shown as cryptic hex strings
+- Clicking any entity row in the dialog opens the full entity detail dialog
+
+#### Browser Mod Dialog
+- **Active browser detection** — rows show a green "● Active" badge or blue "● Visible" badge based on `binary_sensor.*_active` and `sensor.*_visibility` entity states; current path shown for active/visible browsers; sorted active-first
+- **Deregister** button per row calls `browser_mod.deregister_browser` service with the browser's unique ID
+- **Clean up stale** bulk button in footer (orange) — deregisters all browsers with no recent activity
+- **Deregister all but active** button (dark red) — keeps only the currently active browser; shows a confirmation listing the browser being kept
+- **Browser ID chip** — click navigates to `/config/integrations/integration/browser_mod`; separate ⎘ icon copies the ID to clipboard
+
+#### Sidebar Domains Section
+- "All domains" filter moved from the toolbar dropdown into a dedicated **Domains** sidebar section below Quick Filters
+- Enable Selected, Disable Selected, Deselect All, and Refresh moved from the toolbar into the **Actions** sidebar section
+
+### 🐛 Bug Fixes
+- **Toast obscured by dialogs** — raised toast z-index from `10001` to `99999` to escape `backdrop-filter` compositing layers created by dialog overlays; default display duration extended to 10 seconds
+- **Backup label border** — backup checkbox label now uses green border/text (`var(--em-success)`) to match the Update button style instead of the muted grey border
+- **Device names missing** — entity list dialogs now show proper device names; backend was not fetching `name_by_user`/`name` from the device registry — raw device UUIDs were displayed instead
+- **Hash UUID integration groups** — entity list dialog no longer displays raw 32-char hex config entry IDs as integration group names; these are now bucketed under "Other"
+- **Null access in entity list** — three unguarded `this.data` accesses in the entity list dialog are now null-safe
+- **Hardcoded update colours** — all update row state colours (`is-active`, `is-done`, `is-failed`, spinner, SVG ring) now use CSS variables (`var(--em-primary)`, `var(--em-success)`, `var(--em-danger)`) for full theme compatibility
+
+### 🔧 Backend
+- New `entity_manager/get_entity_details` WebSocket command (admin-only) returning full entity, device, area, config entry, and label data in a single call
+- Added imports: `device_registry`, `area_registry`, `label_registry` from `homeassistant.helpers`
+- `get_disabled_entities` now fetches device name from the device registry and includes it in the response, resolving the "Unknown Device" display issue
+
+---
+
+## Version 2.9.1 - UX Polish & Consistency
+
+### ✨ New Features
+
+#### Bulk Rename Dialog — Per-Entity Mode
+- When entities are selected, the Bulk Rename dialog now shows **one editable row per entity** — old name on the left, new name input pre-filled with the current object_id on the right
+- **"Auto-fill with pattern"** collapsible section lets you apply a find/replace (with optional regex) to all rows at once without leaving the dialog
+- Live counter shows "N of M entities will be renamed" as you type
+- Only rows where the name actually changed are sent to HA — no-ops are skipped
+- Original pattern/find-replace mode is retained when no entities are selected (operates on all visible entities)
+
+#### Stat Cards — Edit Navigation
+- **Automation Edit** button now looks up the entity's `unique_id` from the entity registry and navigates directly to `/config/automation/edit/{uniqueId}` — the correct HA automation editor page
+- **Script Edit** button does the same, navigating to `/config/script/edit/{uniqueId}`
+- YAML-defined automations and scripts (no `unique_id`) fall back to their respective list pages with an explanatory toast notification; toast now correctly names the entity type
+- **Helper Edit** button navigates to `/config/helpers`; template helpers navigate to `/config/template`
+
+#### Stat Cards — Consistent Item Layout
+- Automations, Scripts, and Helpers dialogs now use a shared item renderer with consistent **Edit, Rename, Remove** buttons on every row
+- Entity info (live HA state, mode, last triggered/run, current/max runs, domain-specific attributes) moved into a collapsible **Details** dropdown per item — no separate ℹ button needed
+- Helper Details are domain-aware: `input_number` shows value/min/max/step, `input_select` shows options list, `timer` shows remaining time and finish timestamp, etc.
+
+### 🐛 Bug Fixes
+
+#### Labels Sidebar Stability
+- Labels section no longer flashes "Loading labels..." every time an integration is clicked in the sidebar
+- Implemented cache-first rendering — labels are rendered immediately from cache on subsequent sidebar re-renders; cache is only cleared when the Refresh button is clicked
+- Added missing `_loadAndDisplayLabels()` calls to all 6 sidebar re-render sites (filter button, clear-filter, show-all, collapse-all, smart-groups toggle, integration click)
+
+#### HACS Stat Card Search
+- Search now filters results **live as you type** (no debounce, also listens to the `search` event for browser clear-X button)
+- Fixed items with empty `data-repo-name` attributes being hidden instead of shown — switched from fuzzy data-attribute matching to `textContent.includes()` which matches whatever is visible on screen
+- Added "No results for …" message when the search term matches nothing
+
+---
+
 ## Version 2.9.0 - Documentation & Consistency
 
 ### 🧹 Changelog Completion
@@ -10,21 +128,36 @@
 ### 📚 Version Alignment
 - Updated all version references (manifest, README, package.json, docs) to 2.9.0
 - Synchronized version across frontend, backend, and configuration files
+
 ### ✨ New Features
-- **Lovelace Dashboard Card** - Added documentation and configuration guide for custom `entity-manager-card`
+- **Lovelace Dashboard Card** — added documentation and configuration guide for custom `entity-manager-card`
   - Search and filter entities directly from dashboard
   - Bulk operations support
   - Compact and full-size layout options
   - Integration and domain filtering
-- **Template Sensors** - Added configuration examples for entity statistics
+- **Template Sensors** — added configuration examples for entity statistics
   - Disabled entities count
   - Enabled entities count
   - Total entities tracking
   - Integration-based statistics
   - Automation-ready sensor states
+
 ---
 
-## Version 2.8.1 - UI Polish & Safety
+## Version 2.8.1 - UI Polish, Selection & Contrast Fixes
+
+### ✨ New Features
+- **Integration select-all checkbox** — each integration header now has a "Select all" checkbox that selects/deselects all entities within that integration. Supports indeterminate state when partially selected. Works even when the integration is collapsed (operates directly on data). Clicking the checkbox does not toggle expand/collapse
+- **Updates filter counter** — the Updates filter button now shows the real count of pending HA updates (entities with domain `update.*` and `state = on`)
+- **Bulk rename: selected entity list** — collapsible "Show selected entities" list in the Bulk Rename dialog so you can verify exactly which entities will be renamed before running
+- **Bulk rename: regex help button** — a `?` button next to "Use regex" toggles an inline reference panel with common patterns and capture group examples
+- **Bulk label: selected entity list** — same collapsible entity list in the Add Labels to Selected dialog
+- **Bulk rename placeholders** — Find/Replace inputs now use realistic HA entity name examples (`living_room_temperature` → `lounge_temperature`)
+
+### 🐛 Bug Fixes
+- **Label chip text contrast** — label chips in the Manage Labels dialog now compute text color from the background luminance using a canvas context, handling all CSS color formats including HA's named colors (`yellow`, `amber`, etc.). Previously always used white text, making light-colored labels unreadable
+- **Label dialog Done button** — fixed the Done button not closing the dialog; it was incorrectly bound to the Create button (first `.btn-primary` in the overlay) instead of the button in the actions footer
+- **Sidebar active item contrast** — active sidebar items no longer fill with the primary color as background (which was unreadable on yellow/light themes). Now uses a left border accent with primary color text instead
 
 ### ✨ UI Improvements
 - Replaced browser alerts/prompts with in-app dialogs for themes and filter presets
@@ -44,7 +177,42 @@
 
 ---
 
-## Version 2.8.0 - Docs & QA
+## Version 2.8.0 - Dashboard Intelligence & UX Polish
+
+### ✨ New Features
+
+#### Lovelace Dashboard Inspector
+- **Dashboard overview** — lists all dashboards with view counts, recursive card counts, and direct "Open ↗" links
+- **Card type usage chart** — horizontal bar chart sorted by frequency; cards tagged as `built-in` (blue), `custom:*` (orange), or `unknown` (grey) for all 40+ known HA built-in card types
+- **Entity reference map** — shows every entity referenced across all dashboards, sorted by how many times it appears, with location paths (Dashboard › View)
+- Fixed Lovelace WS API to use correct `url_path` parameter instead of `dashboard_id`
+- Card counting is now fully recursive (counts nested cards inside vertical-stack, horizontal-stack, grid, conditional, picture-elements, etc.)
+
+#### Template Entity Management
+- **Edit dialog** — rename entity_id (object_id part) and display name in one place
+- **Entity ID rename** propagates through HA automatically — UI-created automations and scripts update their references via `entity_registry_updated` event
+- **YAML config update** — new `entity_manager/update_yaml_references` backend command scans all `.yaml` files in the HA config directory and replaces old entity_id with new one using word-boundary regex (safe, won't match partial IDs). Skips `custom_components/`, `.storage/`, `deps/`, `tts/`, `backups/`, `www/`
+- **Remove entity** — removes UI-created template helpers by deleting the config entry (prevents HA recreating on restart); YAML-defined templates removed from registry with a warning
+- Rename result toast shows exactly how many references were updated and in how many files
+
+#### Sidebar Navigation
+- All 6 sidebar sections (Actions, Quick Filters, Labels, Smart Groups, Integrations, Help) are now **collapsible** with an animated `▾` arrow indicator
+- **Default closed** — sidebar starts compact on first load
+- Section open/closed state persisted per-section in `localStorage` — survives page reloads
+
+### 🗑️ Removed
+- **Updates stat card** removed — redundant with HA's built-in update notification button
+
+### 🐛 Bug Fixes
+- Fixed scroll clipping — last entity row was hidden due to `min-height: 100vh` on `#main-content` conflicting with the flex layout container. Fixed by adding `min-height: 0` override on the layout-context rule
+- Added `padding-bottom: 32px` to main content area so last item has breathing room
+- Fixed null access errors in Lovelace dialog when `card.conditions[]` or `view.sections[]` contain null entries
+- Fixed `entities.map()` crash when entities array contains nulls — now uses `filter(Boolean)` before map
+- Fixed entity list sort crash when entities array contains nulls — sort comparator now uses optional chaining
+
+---
+
+## Version 2.7.0 - Tooling & Docs
 
 ### 🧰 Tooling
 - Added CI workflow for linting, type checks, tests, and security scanning
@@ -84,7 +252,7 @@
 
 ### 📈 Statistics & Counts
 - **Live Counts on Filter Buttons**: All, Enabled, Disabled, and Updates buttons now show live counts
-- **Color-Coded Buttons**: 
+- **Color-Coded Buttons**:
   - Green border/text for Enabled filter
   - Red border/text for Disabled filter
   - Amber border/text for Updates filter
@@ -146,13 +314,6 @@
 - Fixed domain dropdown background transparency in dark mode
 - Fixed border visibility in dark mode
 - Improved CSS custom property handling for theme variables
-
-### 📦 Files Modified
-- `frontend/entity-manager-panel.js` - Major UI overhaul
-- `websocket_api.py` - Added rename entity handler
-- `manifest.json` - Version bump and icon addition
-- `icon.svg` - New custom integration icon
-- `__init__.py` - Cache busting support
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## Version 2.8.1 - UI Polish & Safety
+
+### ✨ UI Improvements
+- Replaced browser alerts/prompts with in-app dialogs for themes and filter presets
+- Added clickable stat cards to open automation/script/helper lists
+- Added inline entity list action buttons (info + edit)
+
+### 🔐 Security & Validation
+- Escaped theme names in dropdown rendering to prevent HTML injection
+- Centralized entity ID validation and bulk limit constants
+
+### 🔧 Backend & Services
+- Shared enable/disable helpers across services and WebSocket API with clearer errors
+- Removed outdated service descriptions for bulk/rename/export from services.yaml
+
+### 🧪 Tooling
+- Streamlined CI workflow and added npm-based ESLint config
+
+---
+
+## Version 2.8.0 - Docs & QA
+
+### 🧰 Tooling
+- Added CI workflow for linting, type checks, tests, and security scanning
+- Added ESLint configuration for frontend linting
+
+### 📚 Documentation
+- Overhauled README with detailed feature list, usage, troubleshooting, and architecture notes
+- Updated installation docs with correct repository URL and component path
+
+### 🔧 Internal
+- Formatting and consistency cleanups in backend code
+
+---
+
 ## Version 2.6.1 - Bug Fix
 
 ### 🐛 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Version 2.9.0 - Documentation & Consistency
+
+### 🧹 Changelog Completion
+- Added comprehensive v2.8.0 and v2.8.1 release notes
+- Documented UI improvements, security fixes, and backend refactoring
+- Aligned changelog entries with Git history
+
+### 📚 Version Alignment
+- Updated all version references (manifest, README, package.json, docs) to 2.9.0
+- Synchronized version across frontend, backend, and configuration files
+
+---
+
 ## Version 2.8.1 - UI Polish & Safety
 
 ### ✨ UI Improvements

--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -14,7 +14,7 @@ Solves the common problem of managing hundreds of disabled diagnostic entities (
 
 ## Project Stats
 
-- **Version**: 2.9.0
+- **Version**: 2.9.2
 - **License**: MIT
 - **Language**: Python (backend), JavaScript (frontend)
 - **HA Minimum**: 2024.1.0
@@ -216,6 +216,6 @@ MIT License - Free to use, modify, and distribute
 
 ---
 
-**Version**: 2.9.0
+**Version**: 2.9.2
 **Created**: January 2025
 **Maintainer**: @TheIcelandicguy

--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -14,7 +14,7 @@ Solves the common problem of managing hundreds of disabled diagnostic entities (
 
 ## Project Stats
 
-- **Version**: 2.6.0
+- **Version**: 2.9.0
 - **License**: MIT
 - **Language**: Python (backend), JavaScript (frontend)
 - **HA Minimum**: 2024.1.0
@@ -216,6 +216,6 @@ MIT License - Free to use, modify, and distribute
 
 ---
 
-**Version**: 2.6.0
+**Version**: 2.9.0
 **Created**: January 2025
 **Maintainer**: @TheIcelandicguy

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Entity Manager for Home Assistant
 A powerful, feature-rich Home Assistant integration for managing entities across all your integrations. View, enable, disable, rename, compare, analyze, and bulk-manage entities and firmware updates from a single modern interface.
-![Version](https://img.shields.io/badge/version-2.8.0-blue)
+![Version](https://img.shields.io/badge/version-2.9.0-blue)
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2024.1+-blue)
 ![Downloads](https://img.shields.io/github/downloads/TheIcelandicguy/entity-manager/total?color=brightgreen)
 [![HACS](https://img.shields.io/badge/HACS-Custom-orange)](https://github.com/hacs/integration)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ A powerful, feature-rich Home Assistant integration for managing entities across
   - [Theme System](#theme-system)
   - [Context Menu](#context-menu)
   - [Voice Assistant](#voice-assistant)
+  - [Lovelace Dashboard Card](#lovelace-dashboard-card)
+  - [Template Sensors](#template-sensors)
   - [Statistics Dashboard](#statistics-dashboard)
   - [Mobile & Responsive Design](#mobile--responsive-design)
 - [Installation](#installation)
@@ -205,6 +207,104 @@ Control Entity Manager hands-free with voice commands:
 - *"Deactivate entity {name}"*
 - *"Registry enable/disable {name}"*
 Voice commands enforce admin-only access for safety.
+
+### Lovelace Dashboard Card
+Embed Entity Manager directly into your Lovelace dashboard with the custom card:
+
+```yaml
+type: custom:entity-manager-card
+```
+
+**Card Features:**
+- Search and filter entities by ID, device, or integration
+- Multi-select entity management with bulk operations
+- Quick enable/disable toggle for entities
+- Expandable groups by integration and device
+- Live entity counts and status badges
+- Mobile-friendly responsive layout
+
+**Example Dashboard Configuration:**
+```yaml
+views:
+  - title: Entity Management
+    cards:
+      - type: custom:entity-manager-card
+        title: Manage Entities
+```
+
+**Card Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `state_filter` | string | Filter: `all`, `enabled`, or `disabled` |
+| `integration_filter` | string | Show only entities from specific integration |
+| `domain_filter` | string | Show only entities of specific domain (e.g., `sensor`, `light`) |
+| `show_disabled_only` | boolean | Show only disabled entities (default: false) |
+| `compact_mode` | boolean | Reduce card height with compact layout (default: false) |
+
+### Template Sensors
+Entity Manager exposes template sensors for entity statistics and automation conditions:
+
+**Available Template Sensors:**
+```yaml
+template:
+  - sensor:
+      - name: Entity Manager Disabled Entities
+        unique_id: entity_manager_disabled_count
+        state: "{{ states.entity_manager.disabled_entity_count | default(0) }}"
+        unit_of_measurement: entities
+        state_class: measurement
+        icon: mdi:checkbox-marked-outline
+
+      - name: Entity Manager Enabled Entities
+        unique_id: entity_manager_enabled_count
+        state: "{{ states.entity_manager.enabled_entity_count | default(0) }}"
+        unit_of_measurement: entities
+        state_class: measurement
+        icon: mdi:checkbox-blank-outline
+
+      - name: Entity Manager Total Entities
+        unique_id: entity_manager_total_count
+        state: "{{ states.entity_manager.total_entity_count | default(0) }}"
+        unit_of_measurement: entities
+        state_class: measurement
+        icon: mdi:layers
+
+      - name: Entity Manager Disabled Entities by Integration
+        unique_id: entity_manager_integration_stats
+        state: "{{ states.entity_manager.integration_disabled_stats | default('{}') }}"
+        icon: mdi:layers-multiple
+```
+
+**Using in Automations:**
+```yaml
+automation:
+  - alias: "Alert on too many disabled entities"
+    trigger:
+      - platform: numeric_state
+        entity_id: sensor.entity_manager_disabled_entities
+        above: 100
+    action:
+      - service: persistent_notification.create
+        data:
+          title: "Entity Manager Alert"
+          message: >
+            {{ trigger.to_state.state }} entities are currently disabled.
+            Consider reviewing in Entity Manager panel.
+```
+
+**JSON Sensor for Advanced Tracking:**
+```yaml
+template:
+  - sensor:
+      - name: Entity Manager Export
+        unique_id: entity_manager_export
+        state: "{{ now().isoformat() }}"
+        attributes:
+          disabled_entities: "{{ state_attr('sensor.entity_manager_export', 'disabled_entities') }}"
+          by_integration: "{{ state_attr('sensor.entity_manager_export', 'by_integration') }}"
+          by_domain: "{{ state_attr('sensor.entity_manager_export', 'by_domain') }}"
+```
+
 ### Statistics Dashboard
 The toolbar displays live stats for your Home Assistant instance:
 - Integration count

--- a/README.md
+++ b/README.md
@@ -56,15 +56,18 @@ A powerful, feature-rich Home Assistant integration for managing entities across
 - Case-sensitive and regex pattern matching options
 ### Search & Filtering
 Entity Manager provides multiple ways to find exactly what you need:
+
 | Filter Type | Description |
 |---|---|
-| **Text Search** | Search across entity IDs, names, integrations, and devices in real time |
+| **Fuzzy Search** | Smart search with fuzzy matching -- type "snr" to find "sensor", matches characters in order across entity IDs, names, integrations, and devices |
+| **Text Search** | Instant search across entity IDs, names, integrations, and devices with real-time filtering |
 | **Domain Filter** | Dropdown to filter by entity type (sensor, light, switch, binary_sensor, etc.) |
 | **State Filter** | Toggle between All, Enabled, or Disabled with live entity counts |
 | **Integration Filter** | Click an integration in the sidebar to show only its entities |
 | **Label Filter** | Filter by Home Assistant labels |
 | **Tag Filter** | Filter by custom tags using `#tagname` syntax |
 | **Filter Presets** | Save and load your favorite filter combinations |
+
 All filter buttons show **live counts** with color-coded indicators: green for enabled, red for disabled, amber for updates.
 ### Sidebar Navigation
 A collapsible sidebar provides quick access to every feature:
@@ -307,13 +310,18 @@ template:
 
 ### Statistics Dashboard
 The toolbar displays live stats for your Home Assistant instance:
-- Integration count
-- Device count
-- Total entity count
-- Automation count
-- Script count
-- Helper count
-- Update count (amber-highlighted when updates are available)
+- **Integration count** - Total number of integrations
+- **Device count** - Total number of devices
+- **Total entity count** - All entities across your system
+- **Automation count** - Clickable to view automations list
+- **Script count** - Clickable to view scripts list
+- **Helper count** - Clickable to view input helpers and variables
+- **Template count** - Clickable to view template entities (template sensors, binary sensors, etc.)
+- **HACS count** - Custom integrations from HACS
+- **Lovelace Cards count** - Total cards currently deployed on your dashboards
+- **Update count** - Amber-highlighted when updates are available; clickable to view update details
+
+All counts update in real-time as you make changes. Click on any stat card to view details in a dialog.
 ### Mobile & Responsive Design
 - Fully responsive layout for phones, tablets, and desktops
 - Collapsible sidebar with dedicated mobile toggle button

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Entity Manager for Home Assistant
 A powerful, feature-rich Home Assistant integration for managing entities across all your integrations. View, enable, disable, rename, compare, analyze, and bulk-manage entities and firmware updates from a single modern interface.
-![Version](https://img.shields.io/badge/version-2.9.0-blue)
+![Version](https://img.shields.io/badge/version-2.9.2-blue)
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2024.1+-blue)
 ![Downloads](https://img.shields.io/github/downloads/TheIcelandicguy/entity-manager/total?color=brightgreen)
 [![HACS](https://img.shields.io/badge/HACS-Custom-orange)](https://github.com/hacs/integration)
@@ -23,6 +23,7 @@ A powerful, feature-rich Home Assistant integration for managing entities across
   - [Undo / Redo](#undo--redo)
   - [Filter Presets](#filter-presets)
   - [Column Customization](#column-customization)
+  - [Entity Detail Dialog](#entity-detail-dialog)
   - [Firmware Update Manager](#firmware-update-manager)
   - [Export & Import](#export--import)
   - [Theme System](#theme-system)
@@ -148,17 +149,35 @@ Choose which columns to display in the entity table:
 - Tags
 - Alias
 Toggle columns from the sidebar **Columns** button. Preferences are saved between sessions.
+### Entity Detail Dialog
+Click any entity card (not a button or checkbox) to open a full detail dialog with everything Home Assistant knows about that entity:
+
+| Section | Contents |
+|---------|----------|
+| **Overview** | Entity ID, friendly name, domain, platform, unique ID, aliases |
+| **Current State** | State value (colour-coded) + all attributes sorted A–Z |
+| **Registry** | Entity category, device class, disabled/hidden state, icon, unit, supported features |
+| **Device** | Manufacturer, model, SW/HW version, serial number, config URL, connections |
+| **Integration** | Config entry title, domain, source, version, state |
+| **Area** | Assigned area name and aliases |
+| **Labels** | All HA labels attached to the entity |
+| **State History** | Last 30 days of state changes, newest first |
+
+Action buttons in the dialog footer let you **Rename** or **Enable/Disable** the entity without leaving the dialog.
+
 ### Firmware Update Manager
 A dedicated **Updates** tab to manage all firmware and software updates:
 - View all available updates in one place
 - **Filter by stability**: All Updates, Stable Only, Beta Only
 - **Filter by category**: All Types, Devices Only, Integrations Only
 - **Hide up-to-date** checkbox to focus on pending updates
-- **Select All** checkbox for quick bulk selection
+- **Select All** pill with expanding **Update Selected** button — animates into view when items are selected
 - View **release notes** before updating
-- **Bulk update** multiple items at once
-- Alphabetical sorting by title
-- Live update count tracking
+- **Sequential bulk updates** — runs one at a time for safety; rows progress through Queued → Active → ✓ Updated / ✕ Failed
+- **Live progress ring** — SVG ring tracks exact `update_percentage` when HA reports it; indeterminate spinner otherwise
+- **HA auto-backup banner** — shows and toggles HA's global "backup before update" setting; green when ON, red when OFF; hidden on plain HA Core
+- **Per-entity Backup checkbox** — shown for entities that support backup; "Backup All" header checkbox for bulk selection
+- Alphabetical sorting by title; live update count on filter button
 ### Export & Import
 - **Export entity configurations** to JSON -- includes enabled/disabled states for all entities
 - **Import configurations** from a previously exported JSON file to restore states
@@ -312,16 +331,16 @@ template:
 The toolbar displays live stats for your Home Assistant instance:
 - **Integration count** - Total number of integrations
 - **Device count** - Total number of devices
-- **Total entity count** - All entities across your system
-- **Automation count** - Clickable to view automations list
+- **Total entity count** - Clickable to open a grouped entity list (Integration → Device) — click any entity row to open its full detail dialog
+- **Automation count** - Clickable to view automations list with last-triggered time and edit navigation
 - **Script count** - Clickable to view scripts list
 - **Helper count** - Clickable to view input helpers and variables
-- **Template count** - Clickable to view template entities (template sensors, binary sensors, etc.)
-- **HACS count** - Custom integrations from HACS
-- **Lovelace Cards count** - Total cards currently deployed on your dashboards
-- **Update count** - Amber-highlighted when updates are available; clickable to view update details
+- **Template count** - Clickable to view template entities with state, last active, and edit/remove actions
+- **HACS count** - Clickable to browse your HACS store and installed integrations
+- **Lovelace Cards count** - Clickable to inspect dashboards, card type distribution, and entity references
+- **Update count** - Amber-highlighted when updates are available; clickable to open the Updates view
 
-All counts update in real-time as you make changes. Click on any stat card to view details in a dialog.
+All counts update in real-time as you make changes. Every stat card opens a detail dialog — click any entity row inside a dialog to open the **Entity Detail dialog** showing the full registry entry, device info, all state attributes, area, labels, and 30-day state history.
 ### Mobile & Responsive Design
 - Fully responsive layout for phones, tablets, and desktops
 - Collapsible sidebar with dedicated mobile toggle button
@@ -368,8 +387,10 @@ All counts update in real-time as you make changes. Click on any stat card to vi
 ### Managing Updates
 1. Click the **Updates** filter button in the toolbar
 2. Use the filter dropdowns to narrow by stability or category
-3. Check the **Select All** box or pick individual updates
-4. Click **Update Selected** to apply
+3. Check the **HA auto-backup banner** to confirm your global backup setting is correct
+4. Optionally check the **🛡 Backup** checkbox on rows you want backed up before updating
+5. Check **Select All** (or pick individual rows) — the **Update Selected** button expands to the right
+6. Click **Update Selected**; each row progresses through Queued → Active (progress ring) → ✓ / ✕
 ---
 ## Technical Details
 ### Requirements

--- a/custom_components/entity_manager/CHANGELOG.md
+++ b/custom_components/entity_manager/CHANGELOG.md
@@ -2,6 +2,73 @@
 
 All notable changes to Entity Manager will be documented in this file.
 
+## [2.9.2] - 2026-02-23
+
+### Added
+- **Entity detail dialog**: click any entity card body to open a full info dialog — Overview, State + all attributes, Registry, Device, Integration, Area, Labels, State History (last 30 days). New backend WS command `entity_manager/get_entity_details`
+- **Entity card redesign**: dark header band (device / state chip / time), prominent entity ID, enabled badge, checkbox+star+actions in bottom row
+- **HA auto-backup toggle**: banner in Updates section shows and toggles HA's global `core_backup_before_update` / `add_on_backup_before_update` via hassio API; green/red tinted with descriptive subtitle; hidden on plain HA Core
+- **Per-entity backup checkbox**: shown only when `UpdateEntityFeature.BACKUP` flag is set; "Backup All (N)" header checkbox for bulk selection
+- **Sequential update queue**: bulk updates always run one at a time; rows show Queued → Active (spinner + sweeping progress bar) → Done ✓ / Failed ✕ states
+- **Live update progress ring**: `set hass()` watches entity state; SVG progress ring appears when HA reports `update_percentage`; auto-marks done when entity transitions to `state: off`
+- **Browser mod dialog**: active browser detection, Deregister per-row, Clean up stale, Deregister all but active, browser ID chip with navigate/copy actions
+- **Sidebar Domains section**: domain filter moved from toolbar dropdown into sidebar section below Quick Filters
+- **Sidebar Actions**: Enable Selected, Disable Selected, Deselect All, Refresh moved from toolbar into sidebar Actions section
+- **"Update Selected" pill button**: expands from the right side of the Select All pill via `max-width` CSS animation; zero-width and invisible when nothing is selected
+- **Updates search bar**: repositioned below the action bar for a cleaner layout
+- **Total Entities stat card clickable**: opens grouped entity list (Integration → Device → entities) with status dots and disable badges; hash UUID platform names bucketed under "Other"
+
+### Fixed
+- Toast z-index raised to `99999` (was invisible behind dialogs due to `backdrop-filter` compositing); default duration 10 s
+- Backup label styled with green border/text matching Update button
+- Device names now shown in entity list dialogs — backend fetches `name_by_user`/`name` from device registry (was showing raw device UUIDs)
+- Hash/UUID integration group names no longer shown for raw config entry IDs in entity list dialogs
+- Null guards added for `this.data` accesses in entity list dialog
+- Refresh while on Updates page now reloads updates instead of navigating to entity list
+- All update row state colours use CSS variables for full theme compatibility
+
+### Backend
+- New `entity_manager/get_entity_details` WS command; added `device_registry`, `area_registry`, `label_registry` imports
+- `get_disabled_entities` now includes device `name` field (fetched from device registry)
+
+---
+
+## [2.8.1] - 2026-02-18
+
+### Added
+- **Integration select-all checkbox**: Each integration header has a "Select all" checkbox; supports indeterminate state; works when collapsed
+- **Updates filter counter**: Updates button shows real count of pending HA updates (`update.*` with `state = on`)
+- **Bulk rename — entity list**: Collapsible selected entity list so you can verify before renaming
+- **Bulk rename — regex help**: `?` button toggles inline reference panel with common patterns and capture group examples
+- **Bulk label — entity list**: Collapsible selected entity list in Add Labels dialog
+- **Bulk rename placeholders**: Realistic HA entity name examples in Find/Replace inputs
+
+### Fixed
+- Label chip text contrast: canvas luminance picks dark/light text for any CSS color including HA named colors
+- Label dialog Done button incorrectly targeted Create button; now scoped to `.confirm-dialog-actions`
+- Sidebar active item uses left border accent instead of filled background (fixes white-on-yellow unreadability)
+
+---
+
+## [2.8.0] - 2026-02-18
+
+### Added
+- **Lovelace Dashboard Inspector**: New dialog showing dashboards overview, card type bar chart (built-in/custom/unknown badges), and entity reference map across all dashboards
+- **Template entity editing**: Edit dialog to rename entity_id and display name; renames propagate through HA entity registry (updates UI automations/scripts automatically)
+- **YAML config updater**: `entity_manager/update_yaml_references` backend command — scans all config YAML files and safely replaces renamed entity IDs using word-boundary matching
+- **Template entity removal**: Removes UI-created templates via config entry deletion (prevents restart recreation); YAML templates removed from registry with warning
+- **Collapsible sidebar sections**: All 6 nav sections collapse/expand with animated arrow; default closed; state persisted in localStorage per section
+
+### Changed
+- Lovelace card count is now recursive (includes nested cards in stacks, grids, conditionals, etc.)
+- Lovelace WS API corrected to use `url_path` instead of `dashboard_id`
+- Removed Updates stat card (redundant with HA built-in update notifications)
+
+### Fixed
+- Last entity row cut off at bottom of page — `min-height: 100vh` conflicted with flex layout; resolved with `min-height: 0` override and `padding-bottom: 32px`
+- Null access errors in Lovelace dialog for `card.conditions` and `view.sections` array entries
+- `entities.map()` and `entities.sort()` crash when array contains null entries
+
 ## [2.9.0] - 2026-02-17
 
 ### Added

--- a/custom_components/entity_manager/CHANGELOG.md
+++ b/custom_components/entity_manager/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 All notable changes to Entity Manager will be documented in this file.
 
+## [2.8.1] - 2026-02-17
+
+### Added
+- **UI Dialog Improvements**: Replaced browser alert/confirm/prompt dialogs with custom in-app dialogs for theme management and filter presets
+- **Clickable Statistics**: Automation, Script, and Helper stats in toolbar now clickable to open filtered lists
+- **Entity Action Buttons**: Added info and edit action buttons in entity list dialogs for quick navigation to HA UI
+- **Input Sanitization**: Added `_escapeHtml()` and `_escapeAttr()` methods for safe theme/preset name rendering
+
+### Fixed
+- **XSS Vulnerability**: Escaped theme names and preset names in DOM rendering to prevent HTML injection
+- **Admin Permission Logic**: Improved voice intent authorization checks to explicitly deny non-admin/no-user contexts
+
+### Changed
+- **Code Quality**: Consolidated enable/disable entity logic into shared helpers in `websocket_api.py`
+- **Voice Assistant**: Refactored permission checks for clarity and consistency between enable/disable intents
+- **Services Configuration**: Removed obsolete service definitions (bulk_enable, bulk_disable, rename_entity, export_states) from services.yaml as they're not exposed via service calls
+
+### Technical
+- Moved `VALID_ENTITY_ID` regex to `const.py` for consistency with voice assistant and websocket API
+- Moved `MAX_BULK_ENTITIES` constant to `const.py` for centralized configuration
+
+---
+
+## [2.8.0] - 2026-02-16
+
+### Added
+- ✅ **CI/CD Automation**: Full GitHub Actions workflow for linting, type checking, testing, and security scanning
+  - JavaScript linting with ESLint
+  - Python linting & formatting with Ruff
+  - Type checking with MyPy
+  - Python tests on 3.11 and 3.12
+  - Security scanning with Bandit
+- 📚 **Comprehensive Documentation Overhaul**
+  - Rewrote README with detailed feature descriptions, architecture, and troubleshooting
+  - Added installation corrections and usage walkthroughs
+  - Documented all WebSocket API endpoints and local storage keys
+  - Added use cases, requirements, and disclaimer sections
+- ⚙️ **ESLint Configuration**: Added `.eslintrc.js` for consistent frontend code standards
+
+### Fixed
+- **Installation Docs**: Corrected repository URL from placeholder to `https://github.com/TheIcelandicguy/entity-manager`
+- **Component Path**: Updated install instructions to reference `custom_components/entity_manager` correctly
+
+### Changed
+- **Code Formatting**: Applied consistent formatting across Python backend (spacing, imports)
+- **README Version**: Updated badge from 2.6.0 to 2.8.0
+
+### Technical Details
+- Service schema formatting for consistency
+- Config flow type hints and formatting improvements
+- WebSocket handler formatting and documentation improvements
+
+---
+
 ## [2.7.0] - 2026-02-09
 
 ### Fixed

--- a/custom_components/entity_manager/CHANGELOG.md
+++ b/custom_components/entity_manager/CHANGELOG.md
@@ -7,16 +7,28 @@ All notable changes to Entity Manager will be documented in this file.
 ### Added
 - Complete changelog entries for v2.8.0 and v2.8.1 in root repository
 - Aligned version references across all project files (manifest, README, package.json, docs)
+- **Lovelace Dashboard Card Documentation**: Comprehensive guide for using `custom:entity-manager-card` on Lovelace dashboards
+  - Card configuration options (state_filter, integration_filter, domain_filter, show_disabled_only, compact_mode)
+  - Feature overview and dashboard examples
+  - Integration with Lovelace views and cards
+- **Template Sensors Configuration**: Support for entity statistics tracking
+  - Disabled/enabled entities count sensors
+  - Total entities sensor
+  - Integration statistics sensor
+  - JSON export sensor for automation integration
+  - Examples for using in automations and conditions
 
 ### Changed
 - Updated README version badge to 2.9.0
 - Updated manifest.json version to 2.9.0
 - Updated package.json version to 2.9.0
 - Updated PROJECT_SUMMARY.md version references to 2.9.0
+- Enhanced Table of Contents with new Lovelace and Template Sensors sections
 
 ### Documentation
 - Ensured consistency between Git tags, releases, and version references
 - All documentation now reflects accurate release history
+- Added comprehensive integration examples for dashboard cards and template sensors
 
 ---
 

--- a/custom_components/entity_manager/CHANGELOG.md
+++ b/custom_components/entity_manager/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to Entity Manager will be documented in this file.
 
+## [2.9.0] - 2026-02-17
+
+### Added
+- Complete changelog entries for v2.8.0 and v2.8.1 in root repository
+- Aligned version references across all project files (manifest, README, package.json, docs)
+
+### Changed
+- Updated README version badge to 2.9.0
+- Updated manifest.json version to 2.9.0
+- Updated package.json version to 2.9.0
+- Updated PROJECT_SUMMARY.md version references to 2.9.0
+
+### Documentation
+- Ensured consistency between Git tags, releases, and version references
+- All documentation now reflects accurate release history
+
+---
+
 ## [2.8.1] - 2026-02-17
 
 ### Added

--- a/custom_components/entity_manager/frontend/entity-manager-panel.css
+++ b/custom_components/entity_manager/frontend/entity-manager-panel.css
@@ -1,5 +1,10 @@
 /* Entity Manager Panel Styles */
 
+/* Details/summary arrow rotation in stat card dialogs */
+details[open] .em-details-arrow { transform: rotate(90deg); }
+details summary::-webkit-details-marker { display: none; }
+details summary::marker { display: none; }
+
 entity-manager-panel {
   display: flex;
   flex-direction: column;
@@ -650,9 +655,18 @@ entity-manager-panel.has-bg-image .app-header {
 .toolbar {
   display: flex;
   gap: 12px;
-  margin-bottom: 24px;
+  margin-bottom: 10px;
   flex-wrap: wrap;
   align-items: center;
+}
+
+.toolbar-search {
+  margin-bottom: 16px;
+}
+
+.toolbar-search .search-box {
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .filter-group {
@@ -860,6 +874,21 @@ body.em-dialog-open {
   animation: slideUp 0.3s ease;
   overflow: hidden;
   border: var(--dialog-border-width) solid var(--em-primary-dark);
+}
+
+/* Entity detail dialog: wider + scrollable body */
+.confirm-dialog-box.em-entity-detail {
+  max-width: 680px;
+  display: flex;
+  flex-direction: column;
+  max-height: 90vh;
+}
+
+.confirm-dialog-box.em-entity-detail #em-edd-body {
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+  padding: 0 16px;
 }
 
 @keyframes slideUp {
@@ -1438,6 +1467,36 @@ body.em-dialog-open {
   background: var(--secondary-background-color);
 }
 
+.integration-select-wrapper {
+  display: flex;
+  align-items: center;
+  padding-right: 12px;
+  flex-shrink: 0;
+  z-index: 1;
+}
+
+.integration-select-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.integration-select-checkbox {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  accent-color: var(--primary-color);
+  flex-shrink: 0;
+}
+
+.integration-select-text {
+  font-size: 12px;
+  color: var(--secondary-text-color);
+  white-space: nowrap;
+}
+
 .integration-icon {
   margin-right: 12px;
   transition: transform 0.3s ease;
@@ -1476,6 +1535,10 @@ body.em-dialog-open {
   gap: 8px;
   flex-shrink: 0;
 }
+
+/* Per-integration entity state filters */
+.em-filter-enabled .entity-item[data-disabled="true"]  { display: none; }
+.em-filter-disabled .entity-item[data-disabled="false"] { display: none; }
 
 .device-list {
   padding: 12px 20px 20px 20px;
@@ -1556,12 +1619,99 @@ body.em-dialog-open {
   background: var(--em-bg-primary);
   transition: all 0.2s ease;
   flex: 1 1 300px;
-  gap: 8px;
-  min-width: 0; /* Allow shrinking */
+  gap: 0;
+  min-width: 0;
   max-width: 100%;
   overflow: hidden;
 }
 
+/* Top dark header band: device name + state + time */
+.entity-card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  background: var(--em-bg-secondary);
+  margin: -12px -10px 10px;
+  padding: 7px 10px;
+  border-radius: 6px 6px 0 0;
+  border-bottom: 1px solid var(--em-border-light);
+  min-height: 30px;
+}
+
+.em-label-color-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 4px 0;
+}
+
+.em-label-swatch {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+  padding: 0;
+  transition: transform 0.1s, border-color 0.1s;
+}
+
+.em-label-swatch:hover {
+  transform: scale(1.2);
+}
+
+.em-label-swatch.selected {
+  border-color: white;
+  box-shadow: 0 0 0 2px var(--em-primary);
+  transform: scale(1.15);
+}
+
+.entity-header-device {
+  font-size: 12px;
+  color: var(--em-text-primary);
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+
+.entity-device-name {
+  font-size: 12px;
+  color: var(--em-text-secondary);
+  margin-bottom: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.entity-header-state {
+  font-size: 11px;
+  color: var(--em-text-secondary);
+  background: var(--em-bg-hover);
+  border: 1px solid var(--em-border);
+  border-radius: 4px;
+  padding: 2px 7px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.entity-header-time {
+  font-size: 11px;
+  color: var(--em-text-secondary);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* Body: entity ID + name */
+.entity-card-body {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+/* Legacy top row (used by device-expanded rows) */
 .entity-item-top {
   display: flex;
   align-items: center;
@@ -1571,10 +1721,18 @@ body.em-dialog-open {
 
 .entity-item-bottom {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
+  align-items: center;
   width: 100%;
-  padding-top: 4px;
+  margin-top: 10px;
+  padding-top: 8px;
   border-top: 1px solid var(--em-border-light);
+}
+
+.entity-bottom-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .entity-item:hover {
@@ -1621,9 +1779,10 @@ body.em-dialog-open {
   border-radius: 6px;
   background: var(--em-primary) !important;
   color: white !important;
-  margin-left: 8px;
+  margin-top: 8px;
   font-weight: 600;
   flex-shrink: 0;
+  align-self: flex-start;
 }
 
 .entity-actions {
@@ -1695,7 +1854,60 @@ body.em-dialog-open {
 
 /* Update List Styles */
 .update-select-all {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
   margin-bottom: 12px;
+}
+
+/* Pill that joins "Select All" + "Update (N)" into one expanding element */
+.select-all-pill {
+  display: inline-flex;
+  align-items: center;
+  border: 2px solid var(--em-primary);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--em-bg-primary);
+}
+
+/* Strip individual border/radius from the label when inside the pill */
+.select-all-pill .select-all-label {
+  border: none;
+  border-radius: 0;
+  background: transparent;
+}
+
+/* Update button slides out from within the pill */
+/* Wrapper div collapses to zero — divs have no browser-enforced minimum width */
+.em-update-expand-wrap {
+  max-width: 0;
+  overflow: hidden;
+  flex-shrink: 0;
+  transition: max-width 0.4s ease;
+}
+
+.em-update-expand-wrap.is-visible {
+  max-width: 200px;
+}
+
+/* Button inside has full styling — no collapse logic needed here */
+.em-update-expand-btn {
+  display: block;
+  white-space: nowrap;
+  background: var(--em-success);
+  color: white;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 8px 18px;
+  border: none;
+  border-left: 2px solid rgba(255,255,255,0.3);
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.em-update-expand-btn:hover {
+  opacity: 0.85;
 }
 
 .select-all-label {
@@ -1757,6 +1969,69 @@ body.em-dialog-open {
 
 .update-item.beta {
   border-left: 4px solid var(--em-primary);
+}
+
+/* ── Update row progress states ───────────────────────────────── */
+.update-item.is-queued {
+  opacity: 0.55;
+  border-left: 4px solid var(--em-border);
+}
+
+.update-item.is-active {
+  border: 2px solid var(--em-primary) !important;
+  border-left: 4px solid var(--em-primary) !important;
+  background: rgba(var(--em-primary-rgb, 33, 150, 243), 0.06);
+  position: relative;
+  overflow: hidden;
+}
+
+/* Sweeping indeterminate progress bar at the bottom */
+.update-item.is-active::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: -40%;
+  width: 40%;
+  height: 3px;
+  background: linear-gradient(90deg, transparent, var(--em-primary), transparent);
+  animation: em-update-progress 1.4s ease-in-out infinite;
+}
+
+@keyframes em-update-progress {
+  0%   { left: -40%; }
+  100% { left: 110%; }
+}
+
+.update-item.is-done {
+  border: 2px solid var(--em-success) !important;
+  border-left: 4px solid var(--em-success) !important;
+  background: rgba(var(--em-success-rgb, 76, 175, 80), 0.06);
+}
+
+.update-item.is-failed {
+  border: 2px solid var(--em-danger) !important;
+  border-left: 4px solid var(--em-danger) !important;
+  background: rgba(var(--em-danger-rgb, 244, 67, 54), 0.06);
+}
+
+/* SVG progress ring — shown when entity reports update_percentage */
+.em-ring-fill {
+  transition: stroke-dashoffset 0.4s ease;
+}
+
+/* Spinner used in active state */
+.em-update-spinner {
+  width: 18px;
+  height: 18px;
+  border: 2px solid color-mix(in srgb, var(--em-primary) 30%, transparent);
+  border-top-color: var(--em-primary);
+  border-radius: 50%;
+  flex-shrink: 0;
+  animation: em-spin 0.8s linear infinite;
+}
+
+@keyframes em-spin {
+  to { transform: rotate(360deg); }
 }
 
 .update-checkbox {
@@ -2071,11 +2346,15 @@ body.em-dialog-open {
     flex: 1 1 100%;
     padding: 10px;
     font-size: 1em;
-    gap: 8px;
+    gap: 0;
     display: flex;
     flex-direction: column;
     border: 2px solid var(--em-border) !important;
     background: var(--em-bg-primary);
+  }
+
+  .entity-card-header {
+    margin: -10px -10px 10px;
   }
   
   .entity-item:hover {
@@ -2405,7 +2684,7 @@ body.em-dialog-open {
   border-radius: 8px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
   border-left: 4px solid var(--em-primary);
-  z-index: 10001;
+  z-index: 99999;
   transform: translateX(120%);
   transition: transform 0.3s ease;
   max-width: 400px;
@@ -2641,6 +2920,30 @@ body.em-dialog-open {
   color: var(--em-text-secondary);
   margin-bottom: 8px;
   padding: 0 8px;
+  cursor: pointer;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.sidebar-section-title::after {
+  content: '▾';
+  font-size: 10px;
+  transition: transform 0.2s;
+  opacity: 0.5;
+}
+
+.sidebar-section.section-collapsed .sidebar-section-title {
+  margin-bottom: 0;
+}
+
+.sidebar-section.section-collapsed .sidebar-section-title::after {
+  transform: rotate(-90deg);
+}
+
+.sidebar-section.section-collapsed > *:not(.sidebar-section-title) {
+  display: none;
 }
 
 .sidebar-item {
@@ -2660,8 +2963,11 @@ body.em-dialog-open {
 }
 
 .sidebar-item.active {
-  background: var(--em-primary);
-  color: white;
+  background: var(--em-bg-hover);
+  color: var(--em-primary);
+  border-left: 3px solid var(--em-primary);
+  padding-left: 9px;
+  font-weight: 600;
 }
 
 .sidebar-item .icon {
@@ -2712,8 +3018,9 @@ body.em-dialog-open {
   overflow-y: auto;
   overflow-x: hidden;
   transition: margin-left 0.3s ease;
-  padding: 0;
-  min-width: 0; /* Allow flex item to shrink below content size */
+  padding: 0 0 32px;
+  min-width: 0;
+  min-height: 0; /* Override min-height:100vh so flex container controls the height */
   max-width: 100%;
 }
 

--- a/custom_components/entity_manager/frontend/entity-manager-panel.js
+++ b/custom_components/entity_manager/frontend/entity-manager-panel.js
@@ -5747,7 +5747,7 @@ class EntityManagerPanel extends HTMLElement {
               state: s.state
             }));
         } else if (type === 'hacs') {
-          title = 'HACS Integration Manager';
+          title = 'HACS Downloads';
           color = '#4caf50';
           allowToggle = false;
 
@@ -5817,8 +5817,8 @@ class EntityManagerPanel extends HTMLElement {
           } catch (e) {
             entities = [{
               id: 'hacs-not-found',
-              name: 'HACS data not available',
-              meta: 'Ensure custom_components and www/community are accessible'
+              name: 'HACS downloads not available',
+              meta: 'Restart Home Assistant to enable folder scan'
             }];
           }
         } else if (type === 'lovelace') {

--- a/custom_components/entity_manager/frontend/tests/entity-manager-panel.test.js
+++ b/custom_components/entity_manager/frontend/tests/entity-manager-panel.test.js
@@ -288,19 +288,23 @@ class EntityManagerTests {
     const panel = this.createTestPanel();
     
     // Test seconds
-    this.assertEqual(panel._formatTimeDiff(1000), '1s ago', 'Should format 1 second');
-    this.assertEqual(panel._formatTimeDiff(45000), '45s ago', 'Should format 45 seconds');
-    
+    this.assertEqual(panel._formatTimeDiff(1000), '1s', 'Should format 1 second');
+    this.assertEqual(panel._formatTimeDiff(45000), '45s', 'Should format 45 seconds');
+
     // Test minutes
-    this.assertEqual(panel._formatTimeDiff(60000), '1m ago', 'Should format 1 minute');
-    this.assertEqual(panel._formatTimeDiff(3600000 - 1000), '59m ago', 'Should format 59 minutes');
-    
+    this.assertEqual(panel._formatTimeDiff(60000), '1m', 'Should format 1 minute');
+    this.assertEqual(panel._formatTimeDiff(3600000 - 1000), '59m', 'Should format 59 minutes');
+
     // Test hours
-    this.assertEqual(panel._formatTimeDiff(3600000), '1h ago', 'Should format 1 hour');
-    this.assertEqual(panel._formatTimeDiff(86400000 - 1000), '23h ago', 'Should format 23 hours');
-    
+    this.assertEqual(panel._formatTimeDiff(3600000), '1h', 'Should format 1 hour');
+    this.assertEqual(panel._formatTimeDiff(86400000 - 1000), '23h', 'Should format 23 hours');
+
     // Test days
-    this.assertEqual(panel._formatTimeDiff(86400000), '1d ago', 'Should format 1 day');
+    this.assertEqual(panel._formatTimeDiff(86400000), '1d', 'Should format 1 day');
+
+    // Test null/NaN guards
+    this.assertEqual(panel._formatTimeDiff(null), '?', 'Should handle null');
+    this.assertEqual(panel._formatTimeDiff(NaN), '?', 'Should handle NaN');
   }
 
   async testLazyLoading() {

--- a/custom_components/entity_manager/manifest.json
+++ b/custom_components/entity_manager/manifest.json
@@ -7,7 +7,7 @@
   "codeowners": ["@TheIcelandicguy"],
   "config_flow": true,
   "dependencies": ["frontend"],
-  "version": "2.8.0",
+  "version": "2.9.0",
   "integration_type": "service",
   "iot_class": "calculated"
 }

--- a/custom_components/entity_manager/manifest.json
+++ b/custom_components/entity_manager/manifest.json
@@ -7,7 +7,7 @@
   "codeowners": ["@TheIcelandicguy"],
   "config_flow": true,
   "dependencies": ["frontend"],
-  "version": "2.9.0",
+  "version": "2.9.2",
   "integration_type": "service",
   "iot_class": "calculated"
 }

--- a/custom_components/entity_manager/websocket_api.py
+++ b/custom_components/entity_manager/websocket_api.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -9,12 +10,40 @@ from typing import Any
 import voluptuous as vol
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import label_registry as lr
 
 from .const import DOMAIN, MAX_BULK_ENTITIES, VALID_ENTITY_ID
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def _resolve_trigger_context(
+    hass: HomeAssistant, state: Any
+) -> tuple[str, str | None]:
+    """Return (triggered_by, triggered_by_name) from a state's context.
+
+    triggered_by: 'human' | 'automation' | 'system'
+    triggered_by_name: user display name when human, else None
+    """
+    if state is None:
+        return "system", None
+    ctx = state.context
+    if ctx.user_id:
+        name: str | None = None
+        try:
+            user = await hass.auth.async_get_user(ctx.user_id)
+            if user:
+                name = user.name or None
+        except Exception:
+            pass
+        return "human", name
+    if ctx.parent_id:
+        return "automation", None
+    return "system", None
 
 
 def enable_entity(hass: HomeAssistant, entity_id: str) -> None:
@@ -53,6 +82,7 @@ async def handle_get_disabled_entities(
     """Handle get disabled entities request."""
     try:
         entity_reg = er.async_get(hass)
+        dev_reg = dr.async_get(hass)
         state = msg.get("state", "disabled")
 
         grouped_data: dict[str, Any] = {}
@@ -83,8 +113,14 @@ async def handle_get_disabled_entities(
 
             devices = integration_entry["devices"]
             if device_id not in devices:
+                device_name: str | None = None
+                if device_id != "no_device":
+                    dev = dev_reg.async_get(device_id)
+                    if dev:
+                        device_name = dev.name_by_user or dev.name
                 devices[device_id] = {
                     "device_id": device_id if device_id != "no_device" else None,
+                    "name": device_name,
                     "entities": [],
                     "total_entities": 0,
                     "disabled_entities": 0,
@@ -387,38 +423,60 @@ async def handle_list_hacs_items(
             )
         return items
 
-    def _load_hacs_storage(path: Path) -> list[dict[str, Any]]:
-        if not path.exists():
-            return []
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-        except Exception:
-            return []
+    def _load_hacs_storage(base: Path) -> list[dict[str, Any]]:
+        """Load HACS store from hacs.data (category lists) + hacs.repositories (details)."""
+        hacs_data_path = base / ".storage" / "hacs.data"
+        hacs_repos_path = base / ".storage" / "hacs.repositories"
 
-        raw = data.get("data", data) if isinstance(data, dict) else {}
-        repos = raw.get("repositories", []) if isinstance(raw, dict) else []
+        # Build a detail map keyed by full_name from hacs.repositories
+        details_by_name: dict[str, dict[str, Any]] = {}
+        if hacs_repos_path.exists():
+            try:
+                raw = json.loads(hacs_repos_path.read_text(encoding="utf-8"))
+                for repo in (raw.get("data") or {}).values():
+                    if isinstance(repo, dict) and repo.get("full_name"):
+                        details_by_name[repo["full_name"]] = repo
+            except Exception:
+                pass
+
+        # Build store list from hacs.data (categorised repo lists)
         store: list[dict[str, Any]] = []
-        for repo in repos:
-            if not isinstance(repo, dict):
-                continue
-            store.append(
-                {
-                    "name": repo.get("name")
-                    or repo.get("full_name")
-                    or repo.get("repository")
-                    or "unknown",
-                    "full_name": repo.get("full_name") or repo.get("repository") or "",
-                    "category": (repo.get("category") or repo.get("type") or "unknown").lower(),
-                    "installed": bool(repo.get("installed")),
-                }
-            )
+        if not hacs_data_path.exists():
+            return store
+        try:
+            raw = json.loads(hacs_data_path.read_text(encoding="utf-8"))
+            repos_by_cat = (raw.get("data") or {}).get("repositories") or {}
+            for category, items in repos_by_cat.items():
+                if not isinstance(items, list):
+                    continue
+                for item in items:
+                    if not isinstance(item, dict):
+                        continue
+                    full_name = item.get("full_name") or ""
+                    repo_id = str(item.get("id") or "")
+                    det = details_by_name.get(full_name, {})
+                    name = full_name.split("/")[-1] if "/" in full_name else full_name
+                    store.append(
+                        {
+                            "id": repo_id,
+                            "name": name,
+                            "full_name": full_name,
+                            "category": category,
+                            "description": det.get("description") or "",
+                            "downloads": det.get("downloads") or 0,
+                            "stars": det.get("stargazers_count") or 0,
+                            "last_updated": det.get("last_updated") or "",
+                            "new": bool(item.get("new") or det.get("new")),
+                        }
+                    )
+        except Exception:
+            pass
         return store
 
     try:
         base_path = Path(hass.config.path())
         custom_components = base_path / "custom_components"
         community = base_path / "www" / "community"
-        hacs_storage = base_path / ".storage" / "hacs"
 
         now_ts = datetime.now(timezone.utc).timestamp()
         new_cutoff_ts = now_ts - (7 * 24 * 60 * 60)
@@ -428,11 +486,14 @@ async def handle_list_hacs_items(
             frontend = _list_dirs(community, "frontend")
             installed = integrations + frontend
             new_downloads = [item for item in installed if item.get("mtime", 0) >= new_cutoff_ts]
-            store = _load_hacs_storage(hacs_storage)
+            store = _load_hacs_storage(base_path)
+            # Build a set of installed names for the frontend to cross-reference
+            installed_names = {item["name"].lower() for item in installed}
             return {
                 "integrations": integrations,
                 "frontend": frontend,
                 "installed": installed,
+                "installed_names": list(installed_names),
                 "new_downloads": new_downloads,
                 "store": store,
                 "cutoff_days": 7,
@@ -443,6 +504,407 @@ async def handle_list_hacs_items(
     except Exception as err:
         _LOGGER.error("Error listing HACS items: %s", err, exc_info=True)
         connection.send_error(msg["id"], "hacs_list_failed", str(err))
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "entity_manager/update_entity_display_name",
+        vol.Required("entity_id"): cv.entity_id,
+        vol.Optional("name"): vol.Any(str, None),
+    }
+)
+@websocket_api.require_admin
+@websocket_api.async_response
+async def handle_update_entity_display_name(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Set (or clear) a user-defined display name on an entity."""
+    entity_id = msg["entity_id"]
+    name: str | None = msg.get("name") or None
+    entity_reg = er.async_get(hass)
+    if not entity_reg.async_get(entity_id):
+        connection.send_error(msg["id"], "not_found", f"Entity {entity_id} not found")
+        return
+    entity_reg.async_update_entity(entity_id, name=name)
+    connection.send_result(msg["id"], {"success": True})
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "entity_manager/remove_entity",
+        vol.Required("entity_id"): cv.entity_id,
+    }
+)
+@websocket_api.require_admin
+@websocket_api.async_response
+async def handle_remove_entity(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Remove an entity from the entity registry (and its config entry if UI-created)."""
+    entity_id = msg["entity_id"]
+    entity_reg = er.async_get(hass)
+    entry = entity_reg.async_get(entity_id)
+    if not entry:
+        connection.send_error(msg["id"], "not_found", f"Entity {entity_id} not found")
+        return
+
+    config_entry_id = entry.config_entry_id
+    platform = entry.platform or ""
+
+    # For UI-created template entities: remove the whole config entry so HA
+    # doesn't recreate the entity on restart.
+    if config_entry_id:
+        config_entry = hass.config_entries.async_get_entry(config_entry_id)
+        if config_entry and config_entry.domain == "template":
+            await hass.config_entries.async_remove(config_entry_id)
+            connection.send_result(
+                msg["id"],
+                {"success": True, "removed_config_entry": True, "warning": None},
+            )
+            return
+
+    # YAML-defined or other entities: remove from registry only.
+    entity_reg.async_remove(entity_id)
+    yaml_warning = (
+        "This entity is defined in YAML and will return after the next HA restart."
+        if not config_entry_id and platform == "template"
+        else None
+    )
+    connection.send_result(
+        msg["id"],
+        {"success": True, "removed_config_entry": False, "warning": yaml_warning},
+    )
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "entity_manager/get_automations",
+    }
+)
+@websocket_api.require_admin
+@websocket_api.async_response
+async def handle_get_automations(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Return all automations with last_triggered and trigger context."""
+    try:
+        results: list[dict[str, Any]] = []
+        for state in hass.states.async_all("automation"):
+            attrs = dict(state.attributes)
+            triggered_by, triggered_by_name = await _resolve_trigger_context(hass, state)
+            results.append(
+                {
+                    "entity_id": state.entity_id,
+                    "name": attrs.get("friendly_name") or state.entity_id,
+                    "state": state.state,
+                    "last_triggered": attrs.get("last_triggered"),
+                    "last_changed": state.last_changed.isoformat()
+                    if state.last_changed
+                    else None,
+                    "triggered_by": triggered_by,
+                    "triggered_by_name": triggered_by_name,
+                }
+            )
+        results.sort(key=lambda e: e["entity_id"])
+        connection.send_result(msg["id"], results)
+    except Exception as err:
+        _LOGGER.error("Error getting automations: %s", err, exc_info=True)
+        connection.send_error(msg["id"], "get_failed", str(err))
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "entity_manager/get_template_sensors",
+    }
+)
+@websocket_api.require_admin
+@websocket_api.async_response
+async def handle_get_template_sensors(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Handle get template sensors request."""
+    try:
+        entity_reg = er.async_get(hass)
+        results: list[dict[str, Any]] = []
+        seen: set[str] = set()
+
+        for entity in entity_reg.entities.values():
+            entity_id = entity.entity_id
+            if entity.platform != "template" and not entity_id.startswith("template."):
+                continue
+            seen.add(entity_id)
+            state = hass.states.get(entity_id)
+            attrs: dict[str, Any] = dict(state.attributes) if state else {}
+            connected = attrs.get("entity_id", [])
+            if isinstance(connected, str):
+                connected = [connected]
+            triggered_by, triggered_by_name = await _resolve_trigger_context(hass, state)
+            results.append(
+                {
+                    "entity_id": entity_id,
+                    "name": entity.original_name
+                    or attrs.get("friendly_name")
+                    or entity_id,
+                    "platform": entity.platform or "template",
+                    "disabled": bool(entity.disabled),
+                    "state": state.state if state else None,
+                    "last_changed": state.last_changed.isoformat()
+                    if state and state.last_changed
+                    else None,
+                    "last_updated": state.last_updated.isoformat()
+                    if state and state.last_updated
+                    else None,
+                    "connected_entities": list(connected),
+                    "unit_of_measurement": attrs.get("unit_of_measurement"),
+                    "device_class": attrs.get("device_class"),
+                    "triggered_by": triggered_by,
+                    "triggered_by_name": triggered_by_name,
+                }
+            )
+
+        # Pick up any template.* states not in the registry
+        for state in hass.states.async_all():
+            if state.entity_id.startswith("template.") and state.entity_id not in seen:
+                seen.add(state.entity_id)
+                attrs = dict(state.attributes)
+                connected = attrs.get("entity_id", [])
+                if isinstance(connected, str):
+                    connected = [connected]
+                triggered_by, triggered_by_name = await _resolve_trigger_context(hass, state)
+                results.append(
+                    {
+                        "entity_id": state.entity_id,
+                        "name": attrs.get("friendly_name") or state.entity_id,
+                        "platform": "template",
+                        "disabled": False,
+                        "state": state.state,
+                        "last_changed": state.last_changed.isoformat()
+                        if state.last_changed
+                        else None,
+                        "last_updated": state.last_updated.isoformat()
+                        if state.last_updated
+                        else None,
+                        "connected_entities": list(connected),
+                        "unit_of_measurement": attrs.get("unit_of_measurement"),
+                        "device_class": attrs.get("device_class"),
+                        "triggered_by": triggered_by,
+                        "triggered_by_name": triggered_by_name,
+                    }
+                )
+
+        results.sort(key=lambda e: e["entity_id"])
+        connection.send_result(msg["id"], results)
+    except Exception as err:
+        _LOGGER.error("Error getting template sensors: %s", err, exc_info=True)
+        connection.send_error(msg["id"], "get_failed", str(err))
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "entity_manager/update_yaml_references",
+        vol.Required("old_entity_id"): str,
+        vol.Required("new_entity_id"): str,
+    }
+)
+@websocket_api.require_admin
+@websocket_api.async_response
+async def handle_update_yaml_references(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Replace all occurrences of old_entity_id with new_entity_id in YAML config files."""
+    old_id = msg["old_entity_id"]
+    new_id = msg["new_entity_id"]
+    config_path = Path(hass.config.config_dir)
+
+    # Matches old_entity_id as a whole token — not part of a longer identifier.
+    # Lookbehind excludes alphanumeric, underscore, and dot (prevents matching
+    # e.g. "binary_sensor.x" when searching for "sensor.x").
+    pattern = re.compile(
+        r"(?<![a-zA-Z0-9_\.])" + re.escape(old_id) + r"(?![a-zA-Z0-9_])"
+    )
+
+    # Directories inside config_dir that should never be touched
+    _SKIP = {
+        "custom_components",
+        ".storage",
+        "deps",
+        "tts",
+        "__pycache__",
+        "backups",
+        "www",
+        ".git",
+    }
+
+    def _do_replace() -> dict[str, Any]:
+        results: list[dict[str, Any]] = []
+        errors: list[dict[str, Any]] = []
+
+        for filepath in sorted(config_path.rglob("*.yaml")):
+            # Skip any path whose parent parts include an excluded directory
+            rel = filepath.relative_to(config_path)
+            if any(p in _SKIP or p.startswith(".") for p in rel.parts[:-1]):
+                continue
+            try:
+                content = filepath.read_text(encoding="utf-8")
+                if old_id not in content:
+                    continue
+                new_content, count = pattern.subn(new_id, content)
+                if count:
+                    filepath.write_text(new_content, encoding="utf-8")
+                    results.append({"file": str(rel), "replacements": count})
+            except Exception as exc:  # noqa: BLE001
+                errors.append({"file": str(rel), "error": str(exc)})
+
+        return {
+            "success": True,
+            "files_updated": results,
+            "errors": errors,
+            "total_replacements": sum(r["replacements"] for r in results),
+        }
+
+    result = await hass.async_add_executor_job(_do_replace)
+    _LOGGER.info(
+        "YAML reference update %s → %s: %d replacement(s) in %d file(s)",
+        old_id,
+        new_id,
+        result["total_replacements"],
+        len(result["files_updated"]),
+    )
+    connection.send_result(msg["id"], result)
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "entity_manager/get_entity_details",
+        vol.Required("entity_id"): cv.entity_id,
+    }
+)
+@websocket_api.require_admin
+@websocket_api.async_response
+async def handle_get_entity_details(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Return full details for a single entity from all registries."""
+    entity_id = msg["entity_id"]
+    entity_reg = er.async_get(hass)
+    entry = entity_reg.async_get(entity_id)
+
+    if not entry:
+        connection.send_error(msg["id"], "not_found", f"Entity {entity_id} not found")
+        return
+
+    # Build entity info
+    aliases: list[str] = list(entry.aliases) if entry.aliases else []
+    labels: list[str] = list(entry.labels) if entry.labels else []
+    capabilities = entry.capabilities or {}
+
+    result: dict[str, Any] = {
+        "entity": {
+            "entity_id": entry.entity_id,
+            "unique_id": entry.unique_id,
+            "original_name": entry.original_name,
+            "name": entry.name,
+            "aliases": aliases,
+            "platform": entry.platform,
+            "domain": entry.domain,
+            "config_entry_id": entry.config_entry_id,
+            "device_id": entry.device_id,
+            "area_id": entry.area_id,
+            "entity_category": str(entry.entity_category.value) if entry.entity_category else None,
+            "device_class": entry.device_class,
+            "original_device_class": entry.original_device_class,
+            "icon": entry.icon,
+            "original_icon": entry.original_icon,
+            "disabled_by": str(entry.disabled_by.value) if entry.disabled_by else None,
+            "hidden_by": str(entry.hidden_by.value) if entry.hidden_by else None,
+            "unit_of_measurement": entry.unit_of_measurement,
+            "supported_features": entry.supported_features,
+            "capabilities": {k: str(v) for k, v in capabilities.items()},
+        },
+        "device": None,
+        "area": None,
+        "config_entry": None,
+        "labels": [],
+    }
+
+    # Device registry
+    dev = None
+    if entry.device_id:
+        dev_reg = dr.async_get(hass)
+        dev = dev_reg.async_get(entry.device_id)
+        if dev:
+            result["device"] = {
+                "name": dev.name,
+                "name_by_user": dev.name_by_user,
+                "manufacturer": dev.manufacturer,
+                "model": dev.model,
+                "model_id": getattr(dev, "model_id", None),
+                "sw_version": dev.sw_version,
+                "hw_version": dev.hw_version,
+                "serial_number": getattr(dev, "serial_number", None),
+                "configuration_url": dev.configuration_url,
+                "connections": [[c[0], c[1]] for c in dev.connections],
+                "identifiers": [[i[0], i[1]] for i in dev.identifiers],
+                "area_id": dev.area_id,
+            }
+
+    # Area (entity area takes priority, fall back to device area)
+    area_id = entry.area_id or (dev.area_id if dev else None)
+    if area_id:
+        area_reg = ar.async_get(hass)
+        area = area_reg.async_get_area(area_id)
+        if area:
+            result["area"] = {
+                "id": area.id,
+                "name": area.name,
+                "aliases": list(area.aliases) if area.aliases else [],
+            }
+
+    # Config entry
+    if entry.config_entry_id:
+        ce = hass.config_entries.async_get_entry(entry.config_entry_id)
+        if ce:
+            result["config_entry"] = {
+                "domain": ce.domain,
+                "title": ce.title,
+                "source": ce.source,
+                "version": ce.version,
+                "state": str(ce.state.value),
+                "disabled_by": str(ce.disabled_by.value) if ce.disabled_by else None,
+            }
+
+    # Labels (entity + device)
+    label_reg = lr.async_get(hass)
+
+    if labels:
+        resolved = []
+        for label_id in labels:
+            label = label_reg.async_get_label(label_id)
+            if label:
+                resolved.append({"id": label.label_id, "name": label.name, "color": label.color})
+        result["labels"] = resolved
+
+    dev_label_ids: list[str] = list(dev.labels) if dev and dev.labels else []
+    resolved_dev: list[dict[str, Any]] = []
+    for label_id in dev_label_ids:
+        label = label_reg.async_get_label(label_id)
+        if label:
+            resolved_dev.append({"id": label.label_id, "name": label.name, "color": label.color})
+    result["device_labels"] = resolved_dev
+
+    connection.send_result(msg["id"], result)
 
 
 @callback
@@ -456,4 +918,10 @@ def async_setup_ws_api(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, handle_rename_entity)
     websocket_api.async_register_command(hass, handle_export_states)
     websocket_api.async_register_command(hass, handle_list_hacs_items)
+    websocket_api.async_register_command(hass, handle_get_automations)
+    websocket_api.async_register_command(hass, handle_get_template_sensors)
+    websocket_api.async_register_command(hass, handle_update_entity_display_name)
+    websocket_api.async_register_command(hass, handle_remove_entity)
+    websocket_api.async_register_command(hass, handle_update_yaml_references)
+    websocket_api.async_register_command(hass, handle_get_entity_details)
     _LOGGER.debug("Entity Manager WebSocket API commands registered")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entity-manager",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "private": true,
   "description": "Entity Manager - Home Assistant custom integration",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entity-manager",
-  "version": "2.9.0",
+  "version": "2.9.2",
   "private": true,
   "description": "Entity Manager - Home Assistant custom integration",
   "devDependencies": {


### PR DESCRIPTION
## Summary

- **Entity detail dialog** — click any entity card body to open a full info panel: Overview, Current State + all attributes, Registry, Device, Integration, Area, Labels, 30-day State History. New backend WS command `entity_manager/get_entity_details`
- **Entity card redesign** — dark header band (device / state chip / time-ago), prominent entity ID, enabled/disabled badge, action row at bottom
- **Updates — live progress tracking** — `set hass()` state watcher detects `update_percentage` (SVG ring) and `state: off` (auto-done); no polling
- **Updates — sequential queue** — Queued → Active (spinner + sweeping bar) → ✓ Updated / ✕ Failed per row; toast per step + final summary
- **Updates — HA auto-backup banner** — shows/toggles HA's global backup-before-update setting; green/red tinted; hidden on plain HA Core
- **Updates — per-entity Backup checkbox** — shown for entities with `UpdateEntityFeature.BACKUP`; "Backup All" header checkbox
- **Updates — "Update Selected" pill button** — `max-width` CSS animation expands from Select All pill; zero-width when nothing selected
- **Updates — search bar** repositioned below action bar; refresh on Updates page stays on Updates
- **Total Entities stat card** clickable — grouped entity list (Integration → Device); hash/UUID platform names bucketed under "Other"
- **Browser Mod dialog** — active detection, deregister per-row, clean-up-stale, deregister-all-but-active, browser ID chip
- **Sidebar** — Domains section (moved from toolbar dropdown), Actions section (moved from toolbar)
- **Fix** — device names now shown in entity list dialogs (backend fetches from device registry)
- **Fix** — null guards for `this.data` in entity list dialog
- **Fix** — all update UI colours use CSS variables for full theme compatibility
