### PR TITLE
docs: remove references to non-existent Lovelace dashboard card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,11 +130,6 @@
 - Synchronized version across frontend, backend, and configuration files
 
 ### ✨ New Features
-- **Lovelace Dashboard Card** — added documentation and configuration guide for custom `entity-manager-card`
-  - Search and filter entities directly from dashboard
-  - Bulk operations support
-  - Compact and full-size layout options
-  - Integration and domain filtering
 - **Template Sensors** — added configuration examples for entity statistics
   - Disabled entities count
   - Enabled entities count

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ A powerful, feature-rich Home Assistant integration for managing entities across
   - [Theme System](#theme-system)
   - [Context Menu](#context-menu)
   - [Voice Assistant](#voice-assistant)
-  - [Lovelace Dashboard Card](#lovelace-dashboard-card)
   - [Template Sensors](#template-sensors)
   - [Statistics Dashboard](#statistics-dashboard)
   - [Mobile & Responsive Design](#mobile--responsive-design)
@@ -229,39 +228,6 @@ Control Entity Manager hands-free with voice commands:
 - *"Deactivate entity {name}"*
 - *"Registry enable/disable {name}"*
 Voice commands enforce admin-only access for safety.
-
-### Lovelace Dashboard Card
-Embed Entity Manager directly into your Lovelace dashboard with the custom card:
-
-```yaml
-type: custom:entity-manager-card
-```
-
-**Card Features:**
-- Search and filter entities by ID, device, or integration
-- Multi-select entity management with bulk operations
-- Quick enable/disable toggle for entities
-- Expandable groups by integration and device
-- Live entity counts and status badges
-- Mobile-friendly responsive layout
-
-**Example Dashboard Configuration:**
-```yaml
-views:
-  - title: Entity Management
-    cards:
-      - type: custom:entity-manager-card
-        title: Manage Entities
-```
-
-**Card Options:**
-| Option | Type | Description |
-|--------|------|-------------|
-| `state_filter` | string | Filter: `all`, `enabled`, or `disabled` |
-| `integration_filter` | string | Show only entities from specific integration |
-| `domain_filter` | string | Show only entities of specific domain (e.g., `sensor`, `light`) |
-| `show_disabled_only` | boolean | Show only disabled entities (default: false) |
-| `compact_mode` | boolean | Reduce card height with compact layout (default: false) |
 
 ### Template Sensors
 Entity Manager exposes template sensors for entity statistics and automation conditions:

--- a/custom_components/entity_manager/CHANGELOG.md
+++ b/custom_components/entity_manager/CHANGELOG.md
@@ -74,10 +74,6 @@ All notable changes to Entity Manager will be documented in this file.
 ### Added
 - Complete changelog entries for v2.8.0 and v2.8.1 in root repository
 - Aligned version references across all project files (manifest, README, package.json, docs)
-- **Lovelace Dashboard Card Documentation**: Comprehensive guide for using `custom:entity-manager-card` on Lovelace dashboards
-  - Card configuration options (state_filter, integration_filter, domain_filter, show_disabled_only, compact_mode)
-  - Feature overview and dashboard examples
-  - Integration with Lovelace views and cards
 - **Template Sensors Configuration**: Support for entity statistics tracking
   - Disabled/enabled entities count sensors
   - Total entities sensor


### PR DESCRIPTION
## Summary

- Removed the `### Lovelace Dashboard Card` section from README (TOC entry, YAML card examples, Card Features list, Example Dashboard Configuration, Card Options table)
- Removed fake card documentation entries from both CHANGELOG files
- The real **Lovelace Dashboard Inspector** feature is untouched

## Why

The docs referenced a `custom:entity-manager-card` Lovelace card that was never built and doesn't exist. This caused confusion for users. Entity Manager is a sidebar panel, not a Lovelace card.
