### PR TITLE
fix: orphan detection degrades gracefully when config-entry snapshot fails

### DIFF
--- a/custom_components/entity_manager/frontend/entity-manager-panel.js
+++ b/custom_components/entity_manager/frontend/entity-manager-panel.js
@@ -6982,7 +6982,9 @@ class EntityManagerPanel extends HTMLElement {
             reason = 'missing-entry';
           } else if (!e.is_disabled && unprovided) {
             const entryState = e.config_entry_id ? snap?.states.get(e.config_entry_id) : null;
-            if (!e.config_entry_id || entryState === 'loaded') reason = 'not-loaded';
+            // `!snap` fallback: if config_entries/get failed we can't verify the entry —
+            // still surface unprovided entities as not-loaded rather than hiding them.
+            if (!e.config_entry_id || !snap || entryState === 'loaded') reason = 'not-loaded';
           }
           if (reason) out.push({ ...e, integration: integration.integration, orphanReason: reason });
         });


### PR DESCRIPTION
Edge case found while verifying battery_notes remnant scenarios against the v3.1.0 orphan classifier: if the `config_entries/get` call fails, an entity whose config entry was removed AND that has no state object was silently dropped from orphan detection (the not-loaded gate required a verified `loaded` entry state).

When the snapshot is unavailable, unprovided entities are now surfaced as **Not Loaded** rather than hidden — slightly less precise labeling in that rare failure case, but nothing disappears.

Verified via simulation: all battery_notes leftover scenarios classify correctly — removed entry → Missing Config Entry, stale device pointer → Missing Device, loaded-but-not-providing → Not Loaded, and the snapshot-failure case now degrades to Not Loaded instead of null.